### PR TITLE
Fix typographical error(s)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -252,7 +252,7 @@ To show the most recent added mages : **[recent max=x ]**
 * Changed : Introduce jQuery dialog as new UI element
 * Changed : Call TinyMCE window via admin-ajax
 * Bugfix : Better support for SSL blogs
-* Bugfix : Install/Upgrade failed when table prefix contain captial letters
+* Bugfix : Install/Upgrade failed when table prefix contain capital letters
 * Bugfix : Fix validation issues in Media-RSS
 * Bugfix : Empty tags in XMP Meta causes PHP error
 * Bugfix : Rework load mechanism for slideshow


### PR DESCRIPTION
@highvoltag3, I've corrected a typographical error in the documentation of the [WordPress-Plugin_nextgen-gallery](https://github.com/highvoltag3/WordPress-Plugin_nextgen-gallery) project. Specifically, I've changed captial to capital. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
